### PR TITLE
CodeBlockNode fix and some code refactoring

### DIFF
--- a/app/scripts/models/App.js
+++ b/app/scripts/models/App.js
@@ -100,70 +100,68 @@ define(['backbone', 'Workspaces', 'Node', 'Login', 'Workspace', 'SearchElements'
 
     },
 
-    newWorkspace: function( callback ){
+    newWorkspace: function( callback ) {
 
-      var that = this;
+        $.get("/nws", function (data) {
 
-      $.get("/nws", function(data){
+            var ws = new Workspace(data, {app: this });
+            this.get('workspaces').add(ws);
+            this.set('currentWorkspace', ws.get('_id'));
+            if (callback) {
+                callback(ws);
+            }
 
-        var ws = new Workspace(data, {app: that });
-        that.get('workspaces').add( ws );
-        that.set('currentWorkspace', ws.get('_id') );
-        if (callback) callback( ws );
+        }.bind(this)).fail(function () {
 
-      }).fail(function(){
+            console.error("failed to get new workspace");
 
-        console.error("failed to get new workspace");
-
-      });
-
+        });
     },
 
     newNodeWorkspace: function( callback ){
 
-      var that = this;
+        $.get("/nws", function (data) {
 
-      $.get("/nws", function(data){
+            data.isCustomNode = true;
+            data.guid = this.makeId();
 
-        data.isCustomNode = true;
-        data.guid = that.makeId();
+            var ws = new Workspace(data, { app: this });
 
-        var ws = new Workspace(data, { app: that });
+            this.get('workspaces').add(ws);
+            this.set('currentWorkspace', ws.get('_id'));
+            if (callback) {
+                callback(ws);
+            }
 
-        that.get('workspaces').add( ws );
-        that.set('currentWorkspace', ws.get('_id') );
-        if (callback) callback( ws );
+        }.bind(this)).fail(function () {
 
-      }).fail(function(){
+            console.error("failed to get new workspace");
 
-        console.error("failed to get new workspace");
-
-      });
-
+        });
     },
 
-    loadWorkspace: function( id, callback ){
+    loadWorkspace: function( id, callback ) {
 
-      var ws = this.get('workspaces').get(id);
-      if(ws) return;
+        var ws = this.get('workspaces').get(id);
+        if (ws)
+            return;
 
-      var that = this;
+        $.get("/ws/" + id, function (data) {
 
-      $.get("/ws/" + id, function(data){
+            var ws = this.get('workspaces').get(id);
+            if (ws) return;
 
-        var ws = that.get('workspaces').get(id);
-        if(ws) return;
+            var ws = new Workspace(data, {app: this});
+            this.get('workspaces').add(ws);
+            if (callback) {
+                callback(ws);
+            }
 
-        var ws = new Workspace(data, {app: that});
-        that.get('workspaces').add( ws );
-        if (callback) callback( ws );
+        }.bind(this)).fail(function () {
 
-      }).fail(function(){
+            console.error("failed to get workspace with id: " + id);
 
-        console.error("failed to get workspace with id: " + id);
-
-      });
-
+        });
     },
 
     isBackgroundWorkspace: function(id){
@@ -202,15 +200,13 @@ define(['backbone', 'Workspaces', 'Node', 'Login', 'Workspace', 'SearchElements'
         this.set('currentWorkspace', id);
       }
 
-      var that = this;
+        this.loadWorkspace(id, function (ws) {
 
-      this.loadWorkspace( id, function(ws){
-
-        that.set('currentWorkspace', ws.get('_id') );
-        if (callback) callback( ws );
-
-      });
-
+            this.set('currentWorkspace', ws.get('_id'));
+            if (callback) {
+                callback(ws);
+            }
+        });
     },
 
     updateCurrentWorkspace: function(){

--- a/app/scripts/models/DynamoRunner.js
+++ b/app/scripts/models/DynamoRunner.js
@@ -16,9 +16,6 @@ define(['AbstractRunner', 'commandsMap', 'RecordableCommandsMessage', 'CreateNod
 
         reset: function () {
             AbstractRunner.prototype.reset.call(this);
-        },
-
-        initWorker: function () {
         }
     });
 

--- a/app/scripts/models/Workspace.js
+++ b/app/scripts/models/Workspace.js
@@ -94,9 +94,12 @@ define(['backbone', 'Nodes', 'Connection', 'Connections', 'Runner', 'Node', 'Mar
 
                 this.set('nodes', new Nodes());
                 for(var i = 0; i < data.nodes.length; i++) {
+                    var node = data.nodes[i];
+                    node.duringUploading = true;
                     this.get('nodes').add(nodeFactory.create({
-                        config: data.nodes[i],
-                        workspace: this }))
+                        config: node,
+                        workspace: this
+                    }));
                 }
             },
 
@@ -1116,16 +1119,21 @@ define(['backbone', 'Nodes', 'Connection', 'Connections', 'Runner', 'Node', 'Mar
 
         for (; i < len; i++) {
             resultNode = param.result[i];
-            node = this.app.getCurrentWorkspace().get('nodes').get(param.result[i].nodeID);
+            node = this.app.getCurrentWorkspace().get('nodes').get(resultNode.nodeID);
             if (node) {
-                node.updateValue(param.result[i]);
-                this.app.socket.send(JSON.stringify(new GeometryMessage(param.result[i].nodeID)));
+                node.updateValue(resultNode);
+                if (resultNode.containsGeometryData) {
+                     this.app.socket.send(JSON.stringify(new GeometryMessage(resultNode.nodeID)));
+                }
+                else {
+                     node.clearGeometry();
+                }
             }
         }
     },
 
     updateNodeGeometry: function(param) {
-        var node = this.app.getCurrentWorkspace().get('nodes').get(param.geometryData.nodeID);
+        var node = this.get('nodes').get(param.geometryData.nodeID);
         if (node && param.geometryData.graphicPrimitivesData) {
             node.updateNodeGeometry(param);
         }

--- a/app/scripts/models/nodes/CodeBlockNode.js
+++ b/app/scripts/models/nodes/CodeBlockNode.js
@@ -2,12 +2,19 @@ define(['Node', 'FLOOD'], function (Node, FLOOD) {
 
     return Node.extend({
 
+        defaults: {
+            duringUploading: false
+        },
+
         initialize: function (attrs, vals) {
             var inPort = [],
                 outPort = [],
                 i = 0,
                 len = 0;
 
+            if (attrs.duringUploading) {
+                this.set('duringUploading', true);
+            }
             if (attrs.extra && attrs.extra.inputs) {
                 len = attrs.extra.inputs.length;
             }
@@ -29,6 +36,12 @@ define(['Node', 'FLOOD'], function (Node, FLOOD) {
             this.set('type', new FLOOD.nodeTypes.ServerNode(inPort, outPort));
             this.set('creatingName', 'Code Block');
             this.set('lastValue', '');
+            if (!this.get('failureMessage'))
+                this.set('failureMessage', '');
+            if (!this.get('extra'))
+                this.set('extra',{});
+            if (!this.get('displayedName'))
+                this.set('displayedName', '');
 
             this.initAttrs(attrs, vals);
         },
@@ -42,12 +55,20 @@ define(['Node', 'FLOOD'], function (Node, FLOOD) {
                 updated = true;
             }
 
-            if (!this.get('extra').inputs || !this.get('extra').inputs.equals(codeBlock.InPorts)) {
+            if (!this.get('extra').inputs) {
+                this.get('extra').inputs = [];
+            }
+
+            if (!this.get('extra').inputs.equals(codeBlock.InPorts)) {
                 this.get('extra').inputs = codeBlock.InPorts;
                 updated = true;
             }
 
-            if (!this.get('extra').outputs || !this.get('extra').outputs.equals(codeBlock.OutPorts)) {
+            if (!this.get('extra').outputs) {
+                this.get('extra').outputs = [];
+            }
+
+            if (!this.get('extra').outputs.equals(codeBlock.OutPorts)) {
                 this.get('extra').outputs = codeBlock.OutPorts;
                 updated = true;
             }

--- a/app/scripts/models/nodes/Node.js
+++ b/app/scripts/models/nodes/Node.js
@@ -378,7 +378,12 @@ define(['backbone', 'FLOOD', 'staticHelpers'], function (Backbone, FLOOD, static
         this.addCurves(graphicData, geometries);
 
         this.set('prettyLastValue', geometries);
-    },
+
+        },
+
+        clearGeometry: function() {
+            this.set('prettyLastValue', {});
+        },
 
     addPoints: function (graphicData, geometries) {
         // if we have single points

--- a/app/scripts/views/AppView.js
+++ b/app/scripts/views/AppView.js
@@ -426,7 +426,7 @@ define([  'backbone',
     },
 
     getCurrentWorkspace: function(){
-      return this.get('workspaces').get(this.get('currentWorkspace'));
+      return this.model.get('workspaces').get(this.model.get('currentWorkspace'));
     },
 
     toggleViewer: function(event) {

--- a/app/scripts/views/NodeViews/CodeBlock.js
+++ b/app/scripts/views/NodeViews/CodeBlock.js
@@ -171,11 +171,13 @@ define(['backbone', 'BaseNodeView'], function (Backbone, BaseNodeView) {
             this.input.blur(function () {
 
                 var ex = JSON.parse(JSON.stringify(that.model.get('extra')));
+
                 if (!that.input.val()) {
                     that.selectable = true;
                     that.model.workspace.removeNodeByID(that.model.get('_id'));
                     return;
                 }
+
                 if (ex.code === that.input.val())
                     return;
 
@@ -199,10 +201,10 @@ define(['backbone', 'BaseNodeView'], function (Backbone, BaseNodeView) {
                 }
             }
 
-            this.input.focus();
+            if (!this.model.get('duringUploading'))
+                this.input.focus();
 
             return this;
-
         },
 
         render: function () {


### PR DESCRIPTION
What was wrong with code block node:
Empty code block node should be deleted when it loose the focus - the same behavior is implemented in the Dynamo. So it had been done a code block gets the focus right after its creating. But it doesn't take into account the case when a code block node is being loaded with other nodes. In this case code block shouldn't get the focus - this fix is in this PR.
Also this PR contains some code refactoring and part of changes that had to be in the Geometry PR
