### PR TITLE
REACH-44 Zoom to fit in 3D view

### DIFF
--- a/app/scripts/lib/Viewport.js
+++ b/app/scripts/lib/Viewport.js
@@ -200,7 +200,7 @@ function zoomToFit() {
 
 		var target = new THREE.Vector3(centerX, centerY, centerZ);
 		var vec = new THREE.Vector3();
-		vec.subVectors( new THREE.Vector3( distanceFactor, distanceFactor, distanceFactor ), target );
+		vec.addVectors( new THREE.Vector3( distanceFactor, distanceFactor, distanceFactor ), target );
 		controls.target = target;
 		controls.object.position = vec;
 		camera.updateProjectionMatrix();


### PR DESCRIPTION
Just a small fix for Zoom to Fit in 3D view. Sometimes camera was zoomed too close.
