### PR TITLE
REACH-54 Should support "." delimited searches

### DIFF
--- a/app/scripts/models/DynamoApp.js
+++ b/app/scripts/models/DynamoApp.js
@@ -31,7 +31,7 @@ define(['backbone', 'models/App', 'SocketConnection', 'SearchElement'],
         mapLibraryItems: function(param) {
           this.SearchElements.models = param.libraryItems.map(function(item){
             return new SearchElement({name: item.name, creationName: item.creationName,
-              displayName: item.displayName, category: item.category,
+              displayName: item.displayName, category: item.category, searchTags: item.keywords,
               description: item.description, inPort: item.parameters,
               outPort: item.returnKeys, app: this});
           });

--- a/app/scripts/models/SearchElement.js
+++ b/app/scripts/models/SearchElement.js
@@ -8,6 +8,7 @@ define(['backbone'], function(Backbone) {
       displayName: null,
       category: null,
       description: null,
+      searchTags: [],
       inPort: [],
       outPort: [],
       isCustomNode: false,

--- a/app/scripts/views/ModelsListView.js
+++ b/app/scripts/views/ModelsListView.js
@@ -1,9 +1,66 @@
 define(['backbone', 'SearchElement', 'SearchElementView', 'SearchCategoryView'], function (Backbone, SearchElement, SearchElementView, SearchCategoryView) {
 
+    var regExp, filterString;
+
+    function matchSimpleCondition(tag){
+        return tag.indexOf(filterString) > -1;
+    }
+
+    function matchFuzzyCondition(tag){
+        return regExp.test(tag);
+    }
+
+    function fillElementList(list, matchCondition){
+        var weight, searchElementName, i, tag, names, index;
+        for (i = 0; i < this.tagList.length; i++) {
+            tag = this.tagList[i].tag;
+            if (matchCondition(tag)) {
+                // weight is kinda how much it matches
+                weight = filterString.length / tag.length;
+                names = this.tagList[i].names;
+                for (var j = 0; j < names.length; j++) {
+                    index = list.map(function (e) {
+                        return e.name;
+                    }).indexOf(names[j]);
+
+                    if (index == -1) {
+                        list.push({name: names[j], weight: weight});
+                    }
+                    else if (list[index].weight < weight) {
+                        list[index].weight = weight;
+                    }
+                }
+            }
+        }
+    }
+
+    function containsSpecialCharacters() {
+        return filterString.indexOf("*") > -1 ||
+            filterString.indexOf(".") > -1 ||
+            filterString.indexOf(" ") > -1 ||
+            filterString.indexOf("\\") > -1;
+    }
+
+    function makePattern() {
+        var separator = "(.*)";
+        return separator + filterString.trim()
+            .replace(/\\/g, "\\\\")
+            .replace(/\./g, '\\.')
+            .replace(/\*/g, "\\*")
+            .replace(/ /g, separator)
+            + separator;
+    }
+
     var SearchView = Backbone.View.extend({
 
         tagName: 'ul',
         className: 'list search-list',
+
+        tagList: [],
+
+        maxNumberResults: 10,
+        minResultsForTolerantSearch: 0,
+        topResult: null,
 
         initialize: function (attrs, options) {
             this.app = options.app;
@@ -14,6 +71,7 @@ define(['backbone', 'SearchElement', 'SearchElementView', 'SearchCategoryView'],
         template: _.template(''),
 
         render: function () {
+            this.setSearchTags();
             var result = getNamespaces(this.app.SearchElements.models);
             var categories = result.descendants;
             if($.isEmptyObject(categories))
@@ -62,59 +120,58 @@ define(['backbone', 'SearchElement', 'SearchElementView', 'SearchCategoryView'],
             return this;     
         },
 
-        findElementsByName: function (name) {
+        findElementsBySearchTags: function (name) {
+            if (!name)
+                return;
+
             var result = [],
                 i = 0,
+                creationName,
+                index,
                 len = this.searchElements.length;
 
-            name = name.toLowerCase();
+            var names = this.getFilteredSearchElementNames(name);
             for( ; i < len; i++ ) {
-                if( this.searchElements[i].model.get('name').toLowerCase().indexOf(name) > -1){
+                creationName = this.searchElements[i].model.get('creationName');
+                index = names.indexOf(creationName);
+                if (index > -1) {
+                    // if it's the first result make it top one
+                    if (index == 0)
+                        this.topResult = this.searchElements[i];
                     result.push(this.searchElements[i]);
                 }
+
+                // if we've found all results
+                if (result.length == names.length)
+                    break;
             }
 
             return result;
         },
 
-        findElementByCreationName: function(name){
-            var result = null,
-                i = 0,
-                len = this.searchElements.length;
-
-            name = name.toLowerCase();
-            for( ; i < len; i++ ) {
-                if( this.searchElements[i].model.get('creationName').toLowerCase().indexOf(name) > -1 ){
-                    result = this.searchElements[i];
-                    break;
-                }
-            }
-
-            return result;  
-        },
-
-        expandElements: function(name){
+        expandElements: function(name) {
             var elementsToShow,
                 i = 0,
                 len = 0;
 
             this.detach();
+            this.topResult = null;
 
             //If name is empty, show all categories collapsed
-            if(!name){
+            if (!name) {
                 len = this.searchElements.length;
-                for( ; i < len; i++ ){
+                for (; i < len; i++) {
                     this.searchElements[i].showWithAncestors();
                     this.searchElements[i].toggle(false);
                 }
             }
             else {
-                elementsToShow = this.findElementsByName(name),
+                elementsToShow = this.findElementsBySearchTags(name);
                 len = elementsToShow.length;
                 //First hide all visible elements
                 this.hideElements();
-                
-                for( ; i < len; i++){
+
+                for (; i < len; i++) {
                     elementsToShow[i].showWithAncestors();
                 }
             }
@@ -122,6 +179,67 @@ define(['backbone', 'SearchElement', 'SearchElementView', 'SearchCategoryView'],
             this.attach();
 
             return this;
+        },
+
+        setSearchTags: function() {
+            this.tagList = [];
+            var i, j, searchElementName, tags, tag, index;
+            var models = this.app.SearchElements.models;
+            // generate tagList as array of {tag, creationNames}
+            for (i = 0; i < models.length; i++) {
+                searchElementName = models[i].get('creationName');
+                if (!searchElementName)
+                    searchElementName = models[i].get('name');
+
+                tags = models[i].get('searchTags');
+                if (!tags || !tags.length)
+                    tags = [searchElementName];
+
+                for (j = 0; j < tags.length; j++) {
+                    tag = tags[j];
+
+                    index = this.tagList.map(function (e) {
+                        return e.tag;
+                    }).indexOf(tag);
+
+                    if (index > -1) {
+                        this.tagList[index].names.push(searchElementName);
+                    }
+                    else {
+                        this.tagList.push({tag: tag, names: [searchElementName]});
+                    }
+                }
+            }
+        },
+
+        getFilteredSearchElementNames: function (filter) {
+            filterString = filter.toLowerCase();
+            // array of pair {name, weight}
+            var weightedElements = [];
+
+            fillElementList.call(this, weightedElements, matchSimpleCondition);
+
+            // if we don't have enough results and the filterString
+            // contains special characters, do fuzzy search
+            if (weightedElements.length <= this.minResultsForTolerantSearch
+                && containsSpecialCharacters()) {
+                regExp = new RegExp(makePattern());
+                fillElementList.call(this, weightedElements, matchFuzzyCondition);
+            }
+
+            // sort by weight desc
+            weightedElements.sort(function (a, b) {
+                return b.weight - a.weight;
+            });
+
+            var result = [];
+            for (var i = 0; i < weightedElements.length; i++) {
+                result.push(weightedElements[i].name);
+                if (result.length >= this.maxNumberResults)
+                    break;
+            }
+
+            return result;
         },
 
         hideElements: function() {

--- a/app/scripts/views/SearchView.js
+++ b/app/scripts/views/SearchView.js
@@ -49,7 +49,7 @@ define(['backbone', 'SearchElement', 'SearchElementView', 'ModelsListView'], fun
             }
 
             if (event.keyCode === 13) { // enter key causes first result to be inserted
-                var elementToAdd = this.modelsListView.findElementByCreationName(searchText);
+                var elementToAdd = this.modelsListView.topResult;
                 elementToAdd && this.elementClick(elementToAdd.model);                
 
             } 

--- a/app/scripts/views/WorkspaceControlsView.js
+++ b/app/scripts/views/WorkspaceControlsView.js
@@ -270,7 +270,7 @@ define(['backbone', 'List', 'SearchElement', 'SearchElementView', 'bootstrap', '
         }
 
         if (event.keyCode === 13) { // enter key causes first result to be inserted
-            var elementToAdd = this.modelsListView.findElementByCreationName(searchText);
+            var elementToAdd = this.modelsListView.topResult;
             elementToAdd && this.elementClick(elementToAdd.model);                
 
         } 


### PR DESCRIPTION
Search is implemented in the next scheme:
- the Flood receives search elements, each of them has `searchTags` from the Dynamo;
- `ModelsListView` besides generating categories fills `tagList` array and this array will be used for search;
- search returns limited number of most suitable elements (`weight` is criteria) (the Dynamo shows 15 elements but 15 elements take much space in the Flood. so it is set to 10);
- if nothing is found and search string contains special characters it generates regular expression from this string and does search using it;
- when Enter button is pressed there is no need to do search one more time, just pick the top result element.
