### PR TITLE
Do not send delete connection messages when it's superfluous

### DIFF
--- a/app/scripts/models/Runner.js
+++ b/app/scripts/models/Runner.js
@@ -165,6 +165,8 @@ define(['backbone'], function (Backbone) {
 
 		removeConnection: function(connection){
 
+                        if (connection.silentRemove)
+                             return;
 			var c = connection.toJSON();
 			c.kind = "removeConnection";
 			c.id = connection.get('endNodeId');

--- a/app/scripts/models/Workspace.js
+++ b/app/scripts/models/Workspace.js
@@ -272,7 +272,10 @@ define(['backbone', 'Nodes', 'Connection', 'Connections', 'scheme', 'FLOOD', 'Ru
         .each(function(x){
           if ( nodesToRemove[ x.get('startNodeId') ] || nodesToRemove[ x.get('endNodeId') ] ){
             if ( !connsToRemove[ x.get('_id')  ] ){
-              connsToRemove[ x.get('_id') ] = x.toJSON();
+                // no need to notify Dynamo
+                // it will delete this connectors itself
+                x.silentRemove = true;
+                connsToRemove[ x.get('_id') ] = x.toJSON();
             } 
           }
         });
@@ -495,6 +498,7 @@ define(['backbone', 'Nodes', 'Connection', 'Connections', 'scheme', 'FLOOD', 'Ru
       this.resolver.syncCustomNodesWithWorkspace(workspace);
 
     },
+
     sendCompleteDefinitionRunner: function( id ){
 
       // custom node workspace
@@ -549,11 +553,14 @@ define(['backbone', 'Nodes', 'Connection', 'Connections', 'scheme', 'FLOOD', 'Ru
       var multiCmd = { kind: "multiple", commands: [] };
 
       // remove any existing connection
-      var endNode = this.get('nodes').get(endNodeId)
+      var endNode = this.get('nodes').get(endNodeId);
       if ( !endNode ) return this;
       var existingConnection = endNode.getConnectionAtIndex( endPort );
 
       if (existingConnection != null){
+        // no need to notify Dynamo
+        // it will delete this connector itself
+        existingConnection.silentRemove = true;
         var rmConn = existingConnection.toJSON();
         rmConn.kind = "removeConnection";
         multiCmd.commands.push( rmConn );
@@ -865,7 +872,7 @@ define(['backbone', 'Nodes', 'Connection', 'Connections', 'scheme', 'FLOOD', 'Ru
 
         for (; i < len; i++) {
             resultNode = param.result[i];
-            node = this.app.getCurrentWorkspace().get('nodes').get(param.result[i].nodeId);
+            node = this.get('nodes').get(param.result[i].nodeId);
             if (node) {
                 node.updateValue(param.result[i]);
                 this.app.socket.send(JSON.stringify(new GeometryMessage(param.result[i].nodeId)));

--- a/app/scripts/models/nodes/CodeBlockNode.js
+++ b/app/scripts/models/nodes/CodeBlockNode.js
@@ -43,7 +43,8 @@ define(['Node', 'FLOOD'], function (Node, FLOOD) {
                 updated = true;
             }
 
-            if ((!extraCopy.lineIndices && codeBlock.LineIndices.length > 0) || (extraCopy.lineIndices && !extraCopy.lineIndices.equals(codeBlock.LineIndices))) {
+            if ((!extraCopy.lineIndices && codeBlock.LineIndices.length > 0) 
+	    || (extraCopy.lineIndices && !extraCopy.lineIndices.equals(codeBlock.LineIndices))) {
                 extraCopy.lineIndices = codeBlock.LineIndices;
                 updated = true;
             }
@@ -77,6 +78,9 @@ define(['Node', 'FLOOD'], function (Node, FLOOD) {
             if (updated) {
                 this.set('extra', extraCopy);
                 this.trigger('connections-update');
+            }
+            else {
+                this.trigger('cbn-up-to-date');
             }
         }
     });

--- a/app/scripts/models/nodes/Node.js
+++ b/app/scripts/models/nodes/Node.js
@@ -259,7 +259,7 @@ define(['backbone', 'FLOOD', 'staticHelpers'], function (Backbone, FLOOD, static
       }
 
       // initialize if necessary
-      if ( this.getPorts( isOutput )[portIndex] === undefined )
+      if ( !this.getPorts( isOutput )[portIndex] )
         this.getPorts( isOutput )[portIndex] = [];
 
       // add the connection to the array
@@ -384,11 +384,7 @@ define(['backbone', 'FLOOD', 'staticHelpers'], function (Backbone, FLOOD, static
 
         this.set('prettyLastValue', geometries);
 
-        },
-
-        clearGeometry: function() {
-            this.set('prettyLastValue', {});
-        },
+    },
 
     addPoints: function (graphicData, geometries) {
         // if we have single points


### PR DESCRIPTION
Dynamo deletes connectors without receiving corresponding message from Flood during:
1) deleting a node (it causes to deleting all its connectors);
2) adding a connector into an input port (it causes to deleting existing connector);
3) changing CBN's value in the case when it deletes some CBN's ports (it causes to deleting all connectors from these ports).
If Flood sends the message in third case we get an error in Dynamo. We get no errors if Flood sends the message in first and second cases but it makes Dynamo slower.
So do not send delete connection messages in the cases above.

http://adsk-oss.myjetbrains.com/youtrack/issue/REACH-71
