### PR TITLE
REACH-90 Search feels slow

### DIFF
--- a/app/scripts/views/SearchCategoryView.js
+++ b/app/scripts/views/SearchCategoryView.js
@@ -18,6 +18,7 @@ define(['backbone', 'SearchElementView'], function (Backbone, SearchElementView)
 
         render: function () {
             var $childContainer;
+            this.children = [];
 
             this.$el.html(this.template(this.model));
             $childContainer = this.$el.find('ul').eq(0);
@@ -35,6 +36,7 @@ define(['backbone', 'SearchElementView'], function (Backbone, SearchElementView)
                     searchView: this.searchView
                 });
 
+                this.children.push(view);
                 $childContainer.append(view.render().$el);
             }.bind(this));
 
@@ -50,13 +52,14 @@ define(['backbone', 'SearchElementView'], function (Backbone, SearchElementView)
 
                 this.searchElements.push(view);
 
+                this.children.push(view);
                 $childContainer.append(view.render().$el);
             }.bind(this));
 
             return this;
         },
 
-        toggle: function (event, open) {
+        toggle: function (event, open, withChildren) {
             if( typeof open === 'boolean' ){
                 this.expanded = open;  
             }
@@ -75,16 +78,48 @@ define(['backbone', 'SearchElementView'], function (Backbone, SearchElementView)
 
             //Stop event propagation so the parent elements won't get it
             event && event.preventDefault();
+
+            var child, len;
+            if (withChildren) {
+                len = this.children.length;
+                for (var i = 0; i < len; i++) {
+                    child = this.children[i];
+                    // if it's SearchCategoryView
+                    if (child.children)
+                        child.toggle(event, open, true);
+                }
+            }
             return false;
         },
 
-        show: function(){
+        show: function(withChildren) {
             this.$el.show();
             this.$el.addClass('expanded');
             this.$el.find('ul').eq(0).show();
             this.expanded = true;
+
+            if (withChildren) {
+                var len = this.children.length;
+                for (var i = 0; i < len; i++) {
+                    this.children[i].show(true);
+                }
+            }
+        },
+
+        hide: function() {
+            hideWithChildren(this);
         }
-    });
+    }),
+
+    hideWithChildren = function (parent) {
+        parent.$el.hide();
+        if (parent.children) {
+            var len = parent.children.length;
+            for (var i = 0; i < len; i++) {
+                hideWithChildren(parent.children[i]);
+            }
+        }
+    };
 
     return SearchCategoryView;
 });

--- a/app/scripts/views/SearchElementView.js
+++ b/app/scripts/views/SearchElementView.js
@@ -36,26 +36,20 @@ define(['backbone'], function(Backbone) {
       return false;
     },
 
-    toggle: function(isVisible){
-      iterateAncestors.call(this, this.parent, function(ancestor) {
-          ancestor.toggle(null, isVisible);
-      });      
+    hide: function() {
+        this.$el.hide();
     },
 
-    hide: function(){
-      iterateAncestors.call(this, this.parent, function(ancestor) {
-          ancestor.$el.hide();
-      });      
-
-      this.$el.hide();
+    show: function() {
+        this.$el.show();
     },
 
-    showWithAncestors: function(){        
-      iterateAncestors.call(this, this.parent, function(ancestor) {
-          ancestor.show();
-      });
+    showWithAncestors: function() {
+        iterateAncestors.call(this, this.parent, function (ancestor) {
+            ancestor.show();
+        });
 
-      this.$el.show();
+        this.$el.show();
     }
   }),
 


### PR DESCRIPTION
Main wasting of time was calling a method of a category many times when it needs only 1 time. For example when Flood hides all elements with their categories it calls hide on elements themselves. Each element calls hide method for each parent category and therefore for one category number of calls equals to number of all its child elements but only one call should be.

The algorithm of search is improved as well.

I added into code time variable at the begin of search and at the end. And made showing in console time in milliseconds while search. Here's my small statistic before improving code and after:

![reach-90](https://cloud.githubusercontent.com/assets/7658189/4766325/c0ed745c-5b4e-11e4-866b-48d85e11213f.png)
