### PR TITLE
Remove scrollbar in search

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -319,7 +319,7 @@ input[type="button"].btn-block {
 
 .workspace-search-container ul {
     max-height: 500px;
-    overflow-y: scroll;
+    overflow-y: auto;
     list-style: none;
     padding: 0;
     margin: 0;


### PR DESCRIPTION
Elements in search menu always have had a scrollbar. 
![capture](https://cloud.githubusercontent.com/assets/2545968/4896823/a1437df4-63ff-11e4-8a91-988e44dd451c.PNG)
Now scrollbar shown only if needed.
