### PR TITLE
REACH-99 Nodes lacking output port name should be replaced with arrow

### DIFF
--- a/app/scripts/lib/flood/flood.js
+++ b/app/scripts/lib/flood/flood.js
@@ -829,7 +829,7 @@ define('FLOOD', function() {
         }
         else {
             outPort.forEach(function (x) {
-                outPorts.push(new FLOOD.baseTypes.OutputPort(x, [Number]));
+                outPorts.push(new FLOOD.baseTypes.OutputPort(x || '⇒', [Number]));
             });
         }
 


### PR DESCRIPTION
Port without name now replaced with arrow.
