### PR TITLE
Tooltip issue

### DIFF
--- a/app/styles/main.css
+++ b/app/styles/main.css
@@ -9,8 +9,11 @@ body {
 }
 
 .row, .col {
-    overflow: hidden;
     position: absolute;
+}
+
+.row:not(.search-container), .col {
+    overflow: hidden;
 }
 
 .row {
@@ -1858,7 +1861,7 @@ li.notmatch {
 
 div.tooltip-inner {
     max-width: 400px;
-    white-space: nowrap;
+    white-space: pre-line;
 }
 
 .code-block-input {


### PR DESCRIPTION
[REACH-101 Node descriptions are clipped in double click search](http://adsk-oss.myjetbrains.com/youtrack/issue/REACH-101)

Here's a current result:
1) ![search container](https://cloud.githubusercontent.com/assets/7658189/4996407/11b12656-69d0-11e4-88c6-a50b13957d6d.png)

2) ![workspace search container](https://cloud.githubusercontent.com/assets/7658189/4996409/15509bde-69d0-11e4-85f3-b18b49dc723e.png)
