### PR TITLE
Init workspace browser view in time

### DIFF
--- a/app/scripts/models/Login.js
+++ b/app/scripts/models/Login.js
@@ -21,6 +21,7 @@ define(['backbone'], function(Backbone) {
 	  		if (e.email) {
 	  			this.set('email', e.email);
 	  			this.set('isLoggedIn', true);
+                this.trigger('get-logged-in');
 	  		}
 	  		else {
 	  			this.set('isLoggedIn', false);

--- a/app/scripts/views/AppView.js
+++ b/app/scripts/views/AppView.js
@@ -43,7 +43,7 @@ define([  'backbone',
       this.model.on('show-progress', this.showProgress, this);
       this.model.on('hide-progress', this.hideProgress, this);
 
-      this.viewBrowser();
+      this.model.login.on('get-logged-in', this.viewBrowser, this);
 
       this.model.login.on('change:isLoggedIn', this.showHelpOnFirstExperience, this );
       this.model.login.on('change:isFirstExperience', this.showHelpOnFirstExperience, this );
@@ -173,9 +173,6 @@ define([  'backbone',
     },
 
     viewBrowser: function(){
-      if(!this.model.login.get('showing'))
-        return;
-
       if (!this.browserView){
         this.browserView = new WorkspaceBrowserView({model: new WorkspaceBrowser({ app: this.model }) }, { app: this.model });
         this.browserView.render();

--- a/app/scripts/views/BaseSaveUploader.js
+++ b/app/scripts/views/BaseSaveUploader.js
@@ -25,8 +25,8 @@ define(['backbone', 'SaveFileMessage', 'SetModelPositionMessage', 'staticHelpers
             ws.set('name', data.workspaceName);
         }
 
-        var browserViewWorkspaces = this.appView.browserView.model.get('workspaces')
-            .map(mapWorkspaceFromBrowserView);
+        var browserViewWorkspaces = this.appView.browserView ? this.appView.browserView.model.get('workspaces')
+            .map(mapWorkspaceFromBrowserView) : [];
         ws.createNodes(data, browserViewWorkspaces);
         app.changed.currentWorkspace = ws.get('_id');
         this.appView.render();
@@ -161,8 +161,9 @@ define(['backbone', 'SaveFileMessage', 'SetModelPositionMessage', 'staticHelpers
                 prepareWorkspace.call(this, currentWorkspace);
             }
             else if (params.workspaceId) {
-                workspaces = this.appView.browserView.model.get('workspaces').where({ guid: params.workspaceId });
-                if (workspaces.length > 0) {
+                workspaces = this.appView.browserView ? this.appView.browserView.model
+                    .get('workspaces').where({ guid: params.workspaceId }) : [];
+                if (workspaces.length) {
                     app.loadWorkspace(workspaces[0].get('_id'), prepareWorkspace.bind(this), true, true);
                 }
                 else {


### PR DESCRIPTION
It needs to initialize `browserView` before any possible trying to open a file. But we can get `browserView` workspaces only being logged in. So initialize it right after successful login.
In NWK this initializing will never be and it's redundant. So stop using it in NWK
