### PR TITLE
Help fix

### DIFF
--- a/app/scripts/models/Help.js
+++ b/app/scripts/models/Help.js
@@ -28,7 +28,7 @@ define(['backbone'], function(Backbone) {
 	  				targetId : "export-button",
 	  				offset: [20,-110],
 	  				text: "Export all visible geometry to STL for 3D printing"
-	  			},
+	  			}
 	  			// { title: "Zoom",
 	  			// 	targetId : "zoomreset-button",
 	  			// 	offset: [20,-110],

--- a/app/scripts/views/HelpView.js
+++ b/app/scripts/views/HelpView.js
@@ -26,7 +26,8 @@ define(['backbone'], function(Backbone) {
 
         var el = $('#' + section.targetId );
         
-        if (!el) return;
+        if (!el.length) 
+            return;
 
         var offset = el.offset();
         var height = el.height();


### PR DESCRIPTION
`HelpView.render` method fails because `offset` is undefined. And Flood doesn't continue to execute a code after the exception. That's why switching between tabs doesn't work.

Probably the issue with tabs was meant here [REACH-97 Opening dyf file causes home workspace to disappear - should simply focus custom node](http://adsk-oss.myjetbrains.com/youtrack/issue/REACH-97)
