### PR TITLE
REACH-118 Code blocks do not drag with other nodes.

### DIFF
--- a/app/scripts/views/NodeViews/CodeBlock.js
+++ b/app/scripts/views/NodeViews/CodeBlock.js
@@ -281,7 +281,7 @@ define(['backbone', 'ThreeCSGNodeView', 'Prism'], function (Backbone, ThreeCSGNo
         moveNode: function() {
             ThreeCSGNodeView.prototype.moveNode.apply(this, arguments);
 
-            if(!this.input[0].value){
+            if(!this.input[0].innerText){
                 this.input.focus();
             }
 


### PR DESCRIPTION
Selecting of code blocks triggered focus of input area even if they are not empty.
