### PR TITLE
Reset zoom in 3D view if no geometry exists.

### DIFF
--- a/app/scripts/lib/Viewport.js
+++ b/app/scripts/lib/Viewport.js
@@ -226,6 +226,10 @@ function zoomToFit() {
 		controls.object.position = vec;
 		camera.updateProjectionMatrix();
 	}
+	else {
+		controls.reset();
+		camera.updateProjectionMatrix();
+	}
 }
 
 function getBounds(boundingSphere){


### PR DESCRIPTION
When we zoomed to the 3D objects in 3D-view and then we deleted all geometry and tried to click ZoomReset button we wasn't able to reset camera zoom and position.
