### PR TITLE
REACH-137 Custom Node Save As file type is ".dyn", should by ".dyf"

### DIFF
--- a/app/scripts/views/NWKSaveUploaderView.js
+++ b/app/scripts/views/NWKSaveUploaderView.js
@@ -35,7 +35,7 @@ define(['backbone'], function (Backbone) {
                 var guid = this.model.getCurrentWorkspaceGuid();
                 var path = this.model.getPathByGuid(guid);
                 if (!path)
-                    path = this.app.getCurrentWorkspace().get('name');
+                    path = this.model.app.getCurrentWorkspace().get('name');
 
                 if (!guid)
                     this.$el.find('#savefile').attr('accept', dyn);


### PR DESCRIPTION
[REACH-137 Custom Node Save As file type is ".dyn", should by ".dyf"](http://adsk-oss.myjetbrains.com/youtrack/issue/REACH-137)
