### PR TITLE
Keep closed custom node workspaces in background

### DIFF
--- a/app/scripts/models/UnsavedWorkspaceChangesHandler.js
+++ b/app/scripts/models/UnsavedWorkspaceChangesHandler.js
@@ -44,12 +44,16 @@ define(['backbone', 'HasUnsavedChangesMessage'], function(Backbone, HasUnsavedCh
         closeWorkspaceTab: function (data) {
             var saveUploader = this.app.saveUploader;
             var ws = saveUploader.getWorkspaceByGuid(data.guid);
-            this.app.get('workspaces').remove(ws);
+            if (ws.get('isCustomNode')) {
+                this.app.get('workspaces').trigger('hide', ws);
+            }
+            else {
+                this.app.get('workspaces').remove(ws);
+            }
         },
 
         clearHomeWorkspace: function (data) {
             var saveUploader = this.app.saveUploader;
-            var ws = saveUploader.getWorkspaceByGuid(data.guid);
             // ensure it's Home workspace
             if (!data.guid) {
                 saveUploader.clearHomeWorkspace();

--- a/app/scripts/views/AppView.js
+++ b/app/scripts/views/AppView.js
@@ -35,6 +35,7 @@ define([  'backbone',
 
       this.model.get('workspaces').on('add', this.addWorkspaceTab, this);
       this.model.get('workspaces').on('remove', this.removeWorkspaceTab, this);
+      this.model.get('workspaces').on('hide', this.hideWorkspaceTab, this);
       this.model.on('change:showingSettings', this.viewSettings, this);
       this.model.on('change:showingFeedback', this.viewFeedback, this);
       this.model.on('change:showingHelp', this.viewHelp, this);
@@ -347,26 +348,37 @@ define([  'backbone',
       }
     },
 
-    removeWorkspaceTab: function(workspace){
-      var workspaceId = workspace.get('_id');
+    removeWorkspaceTab: function(workspace) {
+        this.hideWorkspaceTab(workspace);
 
-      // The Workspace can no longer be current
-      workspace.set('current', false);
+        var workspaceId = workspace.get('_id');
+        this.workspaceViews[workspaceId].$el.remove();
+        delete this.workspaceViews[workspaceId];
+        this.model.removeWorkspaceFromBackground(workspaceId);
+        workspace.dispose();
+    },
 
-       // check if the removed workspace is the current one
-      if (workspaceId == this.model.get('currentWorkspace') ){
+    hideWorkspaceTab: function(workspace) {
+        var workspaceId = workspace.get('_id');
 
-        // are there any more workspaces?
-        if ( this.model.get('workspaces').length != 0 ) {
-            this.model.set('currentWorkspace', this.model.get('workspaces').first().get('_id'));
+        // The Workspace can no longer be current
+        workspace.set('current', false);
+
+        // check if the removed workspace is the current one
+        if (workspaceId === this.model.get('currentWorkspace')) {
+            // are there any more workspaces?
+            var visibleWorkspaces = this.model.get('workspaces').filter(function (ws) {
+                return !this.isBackgroundWorkspace(ws.get('_id'));
+            }.bind(this.model));
+
+            if (visibleWorkspaces.length) {
+                this.model.set('currentWorkspace', visibleWorkspaces[0].get('_id'));
+            }
         }
-      }
-      
-      this.workspaceTabViews[workspaceId].$el.remove();
-      delete this.workspaceTabViews[workspaceId];
-      this.workspaceViews[workspaceId].$el.remove();
-      delete this.workspaceViews[workspaceId];
-      workspace.dispose();
+
+        this.workspaceTabViews[workspaceId].$el.remove();
+        delete this.workspaceTabViews[workspaceId];
+        this.model.setWorkspaceToBackground(workspaceId);
     },
 
     getCurrentWorkspaceCenter: function(){

--- a/app/scripts/views/WorkspaceTabView.js
+++ b/app/scripts/views/WorkspaceTabView.js
@@ -98,7 +98,7 @@ define(['backbone'], function(Backbone) {
                 app.trigger('closing-request', this.model);
             }
             else {
-                app.get('workspaces').remove(this.model);
+                app.get('workspaces').trigger('hide', this.model);
             }
         }
         else {


### PR DESCRIPTION
[REACH-128 Redesign WorkspaceResolver](http://adsk-oss.myjetbrains.com/youtrack/issue/REACH-128):
"If we open a custom node from workspaces list this cn will be added
into nodes list to have a possibility to create its instances but if we
close this tab this cn won't be removed from the list and we'll get an
error on trying to create this cn instance;"

My solution is to keep custom node workspaces in background rather than delete. So all custom nodes in search list are available to be created.
The same behavior has Dynamo - on closing a custom node tab its workspace isn't deleted.