### PR TITLE
REACH-158 When opening file in Dynamo on the web, many connectors are incorrectly white

### DIFF
--- a/app/scripts/views/ConnectionView.js
+++ b/app/scripts/views/ConnectionView.js
@@ -17,10 +17,22 @@ define(['backbone'], function(Backbone) {
       this.workspace = args.workspace;
       this.workspaceView = args.workspaceView;
 
-      if (this.model.startNode){
-        this.model.startNode.on('change:ignoreDefaults', this.render, this);
+      var startNode = this.model.startNode;
+      if (startNode){
+        startNode.on('change:ignoreDefaults', this.render, this);
+        this.listenTo(startNode, 'connection', this.redrawIfNeed);
+        this.listenTo(startNode, 'disconnection', this.redrawIfNeed);
       }
 
+    },
+
+    redrawIfNeed: function (index, isOutput) {
+        // if an output port was connected/disconnected
+        // it doesn't affect other output connectors
+        if (isOutput)
+            return;
+
+        this.updateColor();
     },
 
     delegateEvents: function() {


### PR DESCRIPTION
The bug has occurred because of no reaction on adding/deleting a connector. 
In case of opening a file some output connectors were added before adding input ones, got white color and didn't update their color after adding input connectors.