### PR TITLE
REACH-171 Challenging to set name of a node in node dialog

### DIFF
--- a/app/scripts/views/NodeViews/Base.js
+++ b/app/scripts/views/NodeViews/Base.js
@@ -23,7 +23,8 @@ define(['backbone', 'jqueryuidraggable', 'bootstrap', 'Hammer'], function(Backbo
       'change .use-default-checkbox': 'useDefaultClick',
       'blur .name-input': 'updateName',
       'click .toggle-vis': 'toggleGeomVis',
-      'click .rep-type': 'replicationClick'
+      'click .rep-type': 'replicationClick',
+      'click .name-input': 'nameInputClick'
     },
 
     initialize: function(args) {
@@ -93,10 +94,14 @@ define(['backbone', 'jqueryuidraggable', 'bootstrap', 'Hammer'], function(Backbo
 
     },
 
+    nameInputClick: function(e){
+      e.stopPropagation();
+    },
+
     // should be part of nodeView subclass
     toggleGeomVis: function(e) {
       this.model.set('visible', !this.model.get('visible') );
-      e.stopPropagation()
+      e.stopPropagation();
     },
 
     makeDraggable: function() {

--- a/app/scripts/views/NodeViews/CodeBlock.js
+++ b/app/scripts/views/NodeViews/CodeBlock.js
@@ -21,6 +21,7 @@ define(['backbone', 'ThreeCSGNodeView'], function (Backbone, ThreeCSGNodeView) {
             this.$el.on('mouseup', adjustElements.bind(this));
             this.$el.on('mousemove', adjustElements.bind(this));
 
+            // Get a value of the cancel option before it is set to avoid losing previous value
             var cancelOption = this.$el.draggable( 'option', 'cancel' );
             if(!cancelOption.match(/.code-block-input/i))
                 this.$el.draggable( 'option', 'cancel', cancelOption + ',.code-block-input' );

--- a/app/scripts/views/NodeViews/CodeBlock.js
+++ b/app/scripts/views/NodeViews/CodeBlock.js
@@ -21,7 +21,10 @@ define(['backbone', 'ThreeCSGNodeView'], function (Backbone, ThreeCSGNodeView) {
             this.$el.on('mouseup', adjustElements.bind(this));
             this.$el.on('mousemove', adjustElements.bind(this));
 
-            this.$el.draggable({ cancel: '.code-block-input' });
+            var cancelOption = this.$el.draggable( 'option', 'cancel' );
+            if(!cancelOption.match(/.code-block-input/i))
+                this.$el.draggable( 'option', 'cancel', cancelOption + ',.code-block-input' );
+            
         },
 
         getCustomContents: function () {


### PR DESCRIPTION
Now "..." menu stays open after clicking on the name field.
Also it turns out that "cancel" option in "draggable" have some values by default, so now we include new value to the old one.