### PR TITLE
REACH-181 Remove App references from Workspace

### DIFF
--- a/app/scripts/models/DynamoApp.js
+++ b/app/scripts/models/DynamoApp.js
@@ -8,7 +8,14 @@ define(['backbone', 'models/App', 'SocketConnection', 'SearchElement', 'SaveUplo
                 this.listenTo(this, 'libraryItemsList-received:event', this.mapLibraryItems);
                 this.saveUploader = new SaveUploader({ app: this });
                 this.listenTo(this.saveUploader, 'request-workspace-browser-refresh', this.refreshWorkspaceBrowser);
+                this.listenTo(this, 'computation-completed:event', this.updateNodes);
                 App.prototype.initialize.call(this);
+            },
+
+            updateNodes: function(e){
+                this.get('workspaces').forEach(function(ws){
+                    ws.updateNodeValues(e);
+                });
             },
 
             fetch: function (options) {

--- a/app/scripts/models/DynamoRunner.js
+++ b/app/scripts/models/DynamoRunner.js
@@ -3,6 +3,7 @@ define(['AbstractRunner', 'commandsMap', 'RecordableCommandsMessage', 'CreateNod
 
     var DynamoRunner =  AbstractRunner.extend({
         initialize: function (attrs, vals) {
+            this.socket = vals.socket;
             AbstractRunner.prototype.initialize.call(this, attrs, vals);
         },
 
@@ -10,7 +11,7 @@ define(['AbstractRunner', 'commandsMap', 'RecordableCommandsMessage', 'CreateNod
             if (commands.hasOwnProperty(data.kind)) {
                 var messages = commands[data.kind].call(this, data);
                 if (messages)
-                    this.app.socket.send(messages);
+                    this.socket.send(messages);
             }
 
             AbstractRunner.prototype.postMessage.call(this, data, quiet);
@@ -21,7 +22,7 @@ define(['AbstractRunner', 'commandsMap', 'RecordableCommandsMessage', 'CreateNod
         },
 
         updateNode: function (node) {
-            this.app.socket.send(createMessage.call(this, UpdateModelValueCommand.syncProperties({ full: true }, node.attributes)));
+            this.socket.send(createMessage.call(this, UpdateModelValueCommand.syncProperties({ full: true }, node.attributes)));
 
             AbstractRunner.prototype.updateNode.call(this, node);
         },

--- a/app/scripts/models/Runner.js
+++ b/app/scripts/models/Runner.js
@@ -8,7 +8,6 @@ define(['backbone'], function (Backbone) {
 
         initialize: function (atts, vals) {
 
-            this.app = vals.app;
             var ws = vals.workspace;
             this.workspace = ws;
 

--- a/app/scripts/models/UnsavedWorkspaceChangesHandler.js
+++ b/app/scripts/models/UnsavedWorkspaceChangesHandler.js
@@ -17,7 +17,7 @@ define(['backbone', 'HasUnsavedChangesMessage'], function(Backbone, HasUnsavedCh
             this.app.get('workspaces').each(this.setWorkspaceProperty.bind(this));
             this.listenTo( this.app.get('workspaces'), 'add', this.setWorkspaceProperty);
 
-            this.listenTo( this.app, 'closing-request', this.closingRequest);
+            this.listenTo( this.app.get('workspaces'), 'closing-request', this.closingRequest);
             this.listenTo( attrs.saveUploader, 'clear-home-request', this.clearHomeRequest );
 
             this.listenTo( attrs.saveUploader, 'saving-is-done', this.continueAction );

--- a/app/scripts/views/AppView.js
+++ b/app/scripts/views/AppView.js
@@ -50,7 +50,7 @@ define([  'backbone',
         this.listenTo(this.model.login, 'change:isFirstExperience', this.showHelpOnFirstExperience);
 
         this.pendingRequestsCount = 0;
-        this.listenTo(this.model, 'requestGeometry', function(){
+        this.listenTo(this.model.get('workspaces'), 'requestGeometry', function(){
             if(this.pendingRequestsCount === 0)
                 this.showProgress();
             this.pendingRequestsCount++;

--- a/app/scripts/views/WorkspaceTabView.js
+++ b/app/scripts/views/WorkspaceTabView.js
@@ -85,20 +85,18 @@ define(['backbone'], function(Backbone) {
     },
 
     click: function(e) {
-      this.model.app.set('currentWorkspace', this.model.get('_id'));
+      this.model.trigger('setCurrentWorkspace', this.model.get('_id'));
     },
 
     remove: function(e) {
-        var app = this.model.app;
-
         // don't remove Home workspace
         if (this.model.get('isCustomNode')) {
 
             if (this.model.get('askForUnsavedChanges')) {
-                app.trigger('closing-request', this.model);
+                this.model.trigger('closing-request', this.model);
             }
             else {
-                app.get('workspaces').trigger('hide', this.model);
+                this.model.trigger('hide', this.model);
             }
         }
         else {

--- a/app/scripts/views/WorkspaceView.js
+++ b/app/scripts/views/WorkspaceView.js
@@ -542,7 +542,7 @@ define(['backbone', 'Workspace', 'ConnectionView', 'MarqueeView', 'NodeViewTypes
 
     watchNodeViewEvents: function(nodeView) {
         this.listenTo(nodeView, 'send-array-message', function(message) {
-            this.model.app.socket.send(JSON.stringify(message));
+            this.model.socket.send(JSON.stringify(message));
         });
 
         this.listenTo(nodeView, 'end-port-conn', this.endPortConnection);
@@ -551,7 +551,7 @@ define(['backbone', 'Workspace', 'ConnectionView', 'MarqueeView', 'NodeViewTypes
         });
 
         this.listenTo(nodeView, 'request-open-definition', function(id) {
-            this.model.app.openWorkspace( id );
+            this.model.trigger('openWorkspace', id);
         });
 
         if (nodeView.changeVisibility) {


### PR DESCRIPTION
We still need to pass some App properties (like socket) into workspace, because in another way it would be impossible to use socket during workspace initialization.
Maybe we should extract socket from App and make a separate class for it, so we could use it from anywhere?
